### PR TITLE
removed Plotly opacity slider and moved it to storybook controls

### DIFF
--- a/src/plots/Boxplot.tsx
+++ b/src/plots/Boxplot.tsx
@@ -18,62 +18,62 @@ export interface Props {
   }[];
   xAxisLabel?: string;
   yAxisLabel?: string;
-  defaultYAxisRange? : [Datum, Datum];
-  defaultOrientation?: 'vertical' | 'horizontal';
-  defaultShowRawData?: boolean;
-  defaultShowMean?: boolean;
-  defaultOpacity?: number;
+  defaultYAxisRange? : [Datum, Datum];  // can be changed by plotly's built-in controls
+  orientation?: 'vertical' | 'horizontal';
+  showRawData?: boolean;
+  showMean?: boolean;
+  opacity?: number;
 }
 
-export default function Boxplot(props : Props) {
+export default function Boxplot({ data, orientation, showRawData, showMean, xAxisLabel, yAxisLabel, defaultYAxisRange, opacity } : Props) {
 
-  const data = props.data.map((d) => {
+  const pdata = data.map((d) => {
 
-    const orientationDependentProps = props.defaultOrientation === 'vertical' ? 
+    const orientationDependentProps = orientation === 'vertical' ? 
      { x0: d.label,
-       y: d.rawData && props.defaultShowRawData ? [ d.rawData ] : d.outliers.length ? [d.outliers] : undefined
+       y: d.rawData && showRawData ? [ d.rawData ] : d.outliers.length ? [d.outliers] : undefined
      } :
      { y0: d.label,
-       x: d.rawData && props.defaultShowRawData ? [ d.rawData ] : d.outliers.length ? [d.outliers] : undefined
+       x: d.rawData && showRawData ? [ d.rawData ] : d.outliers.length ? [d.outliers] : undefined
      };
     
     return { upperfence: [d.upperWhisker],
 	     lowerfence: [d.lowerWhisker],
 	     median: [d.median],
 	     mean: d.mean !== undefined ? [d.mean] : undefined,
-	     boxmean: d.mean !== undefined && props.defaultShowMean,
+	     boxmean: d.mean !== undefined && showMean,
 	     q1: [d.q1],
 	     q3: [d.q3],
 	     name: d.label,
-	     boxpoints: d.rawData ? 'all' : 'outliers',
+	     boxpoints: d.rawData && showRawData ? 'all' : 'outliers',
 	     jitter: 0.1, // should be dependent on the number of datapoints...?
 	     marker: {
-	       opacity: props.defaultOpacity,
+	       opacity: opacity,
  	       color: d.color,
 	     },
 	     ...orientationDependentProps,
 	     type: 'box' } as const
   });
 
-  const dependentAxis = props.defaultOrientation === 'vertical' ? 'yaxis' : 'xaxis';
-  const independentAxis = props.defaultOrientation === 'vertical' ? 'xaxis' : 'yaxis';
+  const dependentAxis = orientation === 'vertical' ? 'yaxis' : 'xaxis';
+  const independentAxis = orientation === 'vertical' ? 'xaxis' : 'yaxis';
 
   const layout = {
     [dependentAxis] : {
       rangemode: "tozero" as const,
-      title: props.yAxisLabel,
-      range: props.defaultYAxisRange
+      title: yAxisLabel,
+      range: defaultYAxisRange
     },
     [independentAxis] : {
-      title: props.xAxisLabel
+      title: xAxisLabel
     },
     showlegend: false
   };
-  return <PlotlyPlot data={data} layout={layout} />
+  return <PlotlyPlot data={pdata} layout={layout} />
 }
 
 Boxplot.defaultProps = {
-  defaultOpacity: 0.5,
-  defaultOrientation: 'vertical'
+  opacity: 0.5,
+  orientation: 'vertical'
 }
 

--- a/src/plots/Boxplot.tsx
+++ b/src/plots/Boxplot.tsx
@@ -16,16 +16,16 @@ export interface Props {
                         // but are we trying to remove dependencies on Plotly types?
     outliers : Datum[]
   }[];
-  xAxisLabel?: string;
-  yAxisLabel?: string;
-  defaultYAxisRange? : [Datum, Datum];  // can be changed by plotly's built-in controls
+  independentAxisLabel?: string;
+  dependentAxisLabel?: string;
+  defaultDependentAxisRange? : [Datum, Datum];  // can be changed by plotly's built-in controls
   orientation?: 'vertical' | 'horizontal';
   showRawData?: boolean;
   showMean?: boolean;
   opacity?: number;
 }
 
-export default function Boxplot({ data, orientation, showRawData, showMean, xAxisLabel, yAxisLabel, defaultYAxisRange, opacity } : Props) {
+export default function Boxplot({ data, orientation, showRawData, showMean, independentAxisLabel, dependentAxisLabel, defaultDependentAxisRange, opacity } : Props) {
 
   const pdata = data.map((d) => {
 
@@ -61,11 +61,11 @@ export default function Boxplot({ data, orientation, showRawData, showMean, xAxi
   const layout = {
     [dependentAxis] : {
       rangemode: "tozero" as const,
-      title: yAxisLabel,
-      range: defaultYAxisRange
+      title: dependentAxisLabel,
+      range: defaultDependentAxisRange
     },
     [independentAxis] : {
-      title: xAxisLabel
+      title: independentAxisLabel
     },
     showlegend: false
   };

--- a/src/plots/Boxplot.tsx
+++ b/src/plots/Boxplot.tsx
@@ -22,16 +22,14 @@ export interface Props {
   defaultOrientation?: 'vertical' | 'horizontal';
   defaultShowRawData?: boolean;
   defaultShowMean?: boolean;
+  defaultOpacity?: number;
 }
 
 export default function Boxplot(props : Props) {
 
-  const orientation = props.defaultOrientation ?
-		      (props.defaultOrientation === 'horizontal' ? 'h' : 'v') : 'v';
-
   const data = props.data.map((d) => {
 
-    const orientationDependentProps = orientation === 'v' ? 
+    const orientationDependentProps = props.defaultOrientation === 'vertical' ? 
      { x0: d.label,
        y: d.rawData && props.defaultShowRawData ? [ d.rawData ] : d.outliers.length ? [d.outliers] : undefined
      } :
@@ -43,69 +41,23 @@ export default function Boxplot(props : Props) {
 	     lowerfence: [d.lowerWhisker],
 	     median: [d.median],
 	     mean: d.mean !== undefined ? [d.mean] : undefined,
-	     boxmean: d.mean !== undefined && props.defaultShowMean ,
+	     boxmean: d.mean !== undefined && props.defaultShowMean,
 	     q1: [d.q1],
 	     q3: [d.q3],
 	     name: d.label,
 	     boxpoints: d.rawData ? 'all' : 'outliers',
 	     jitter: 0.1, // should be dependent on the number of datapoints...?
 	     marker: {
-	       opacity: 0.5,
+	       opacity: props.defaultOpacity,
  	       color: d.color,
 	     },
 	     ...orientationDependentProps,
 	     type: 'box' } as const
   });
 
-  const dependentAxis = orientation === 'v' ? 'yaxis' : 'xaxis';
-  const independentAxis = orientation === 'v' ? 'xaxis' : 'yaxis';
+  const dependentAxis = props.defaultOrientation === 'vertical' ? 'yaxis' : 'xaxis';
+  const independentAxis = props.defaultOrientation === 'vertical' ? 'xaxis' : 'yaxis';
 
-  const pointTraceIndices = props.data.map((d, index) => d.rawData || d.outliers.length ? index : -1).filter((i) => i>=0);
-  
-  const opacitySliders = pointTraceIndices.length ? [
-    {          // mostly copy-pasted from DKDK
-      pad: {t: 50},
-      active: 2,         //DKDK this sets the default location of slider: from 0 (left)
-      currentvalue: {
-        visible: true,
-        xanchor: 'left' as const,
-        offset: 10,
-        prefix: 'Opacity = ',
-        suffix: '',
-        font: {
-          color: '#888',
-          size: 20
-        }
-      },
-      steps: [
-        {
-          label: '0',
-          method: 'restyle' as const,
-          args: ['marker.opacity', '0', pointTraceIndices]
-        },
-        {
-          label: '0.25',
-          method: 'restyle' as const,
-          args: ['marker.opacity', '0.25', pointTraceIndices]
-        },
-        {
-          label: '0.5',
-          method: 'restyle' as const,
-          args: ['marker.opacity', '0.5', pointTraceIndices]
-        },
-        {
-          label: '0.75',
-          method: 'restyle' as const,
-          args: ['marker.opacity', '0.75', pointTraceIndices]
-        },
-        {
-          label: '1',
-          method: 'restyle' as const,
-          args: ['marker.opacity', '1', pointTraceIndices]
-        }]
-    }
-  ] : [];
-  
   const layout = {
     [dependentAxis] : {
       rangemode: "tozero" as const,
@@ -115,8 +67,13 @@ export default function Boxplot(props : Props) {
     [independentAxis] : {
       title: props.xAxisLabel
     },
-    showlegend: false,
-    sliders: [...opacitySliders]
+    showlegend: false
   };
   return <PlotlyPlot data={data} layout={layout} />
 }
+
+Boxplot.defaultProps = {
+  defaultOpacity: 0.5,
+  defaultOrientation: 'vertical'
+}
+

--- a/src/stories/Boxplot.stories.tsx
+++ b/src/stories/Boxplot.stories.tsx
@@ -76,41 +76,41 @@ YAxisLabel.argTypes = storyArgTypes(
   YAxisLabel.args = {
     data: [ {...outdoorTemperatureData, label: 'outdoor'},
 	    {...indoorTemperatureData, label: 'indoor'} ],
-    yAxisLabel: "temperature, °C"
+    dependentAxisLabel: "temperature, °C"
 });
 
 export const XAndYAxisLabel : Story<Props> = Template.bind({});
 XAndYAxisLabel.argTypes = storyArgTypes(
   XAndYAxisLabel.args = {
     data: [ {...catData, label: 'cats'}, {...dogData, label: 'dogs'} ],
-    xAxisLabel: "domestic animal",
-    yAxisLabel: "height, cm"
+    independentAxisLabel: "domestic animal",
+    dependentAxisLabel: "height, cm"
 });
 
 export const FixedYAxisRange : Story<Props> = Template.bind({});
 FixedYAxisRange.argTypes = storyArgTypes(
   FixedYAxisRange.args = {
     data: [ {...outdoorTemperatureData, label: 'outdoor'}, {...indoorTemperatureData, label: 'indoor'} ],
-    yAxisLabel: "temperature, °C",
-    xAxisLabel: "location",
-    defaultYAxisRange: [-50,50]
+    dependentAxisLabel: "temperature, °C",
+    independentAxisLabel: "location",
+    defaultDependentAxisRange: [-50,50]
 });
 
 export const FixedTooSmallYAxisRange : Story<Props> = Template.bind({});
 FixedTooSmallYAxisRange.argTypes = storyArgTypes(
   FixedTooSmallYAxisRange.args = {
     data: [ {...outdoorTemperatureData, label: 'outdoor'}, {...indoorTemperatureData, label: 'indoor'} ],
-    yAxisLabel: "temperature, °C",
-    xAxisLabel: "location",
-    defaultYAxisRange: [-10,10]
+    dependentAxisLabel: "temperature, °C",
+    independentAxisLabel: "location",
+    defaultDependentAxisRange: [-10,10]
 });
 
 export const Horizontal : Story<Props> = Template.bind({});
 Horizontal.argTypes = storyArgTypes(
   Horizontal.args = {
     data: [ {...catData, label: 'cats'}, {...dogData, label: 'dogs'} ],
-    xAxisLabel: "domestic animal",
-    yAxisLabel: "height, cm",
+    independentAxisLabel: "domestic animal",
+    dependentAxisLabel: "height, cm",
     orientation: "horizontal"
 });
 
@@ -118,8 +118,8 @@ export const HorizontalLongLabels : Story<Props> = Template.bind({});
 HorizontalLongLabels.argTypes = storyArgTypes(
   HorizontalLongLabels.args = {
     data: [ {...catData, label: 'hungry domestic cats'}, {...dogData, label: 'sleepy domestic dogs'} ],
-    xAxisLabel: "type of domestic animal",
-    yAxisLabel: "height, cm",
+    independentAxisLabel: "type of domestic animal",
+    dependentAxisLabel: "height, cm",
     orientation: "horizontal"
 });
 
@@ -128,8 +128,8 @@ WithRawData.argTypes = storyArgTypes(
   WithRawData.args = {
     data: [ {...catData, label: 'cats', rawData: catRawData}, {...dogData, label: 'dogs', rawData: dogRawData} ],
     showRawData: true,
-    xAxisLabel: "domestic animal",
-    yAxisLabel: "height, cm"
+    independentAxisLabel: "domestic animal",
+    dependentAxisLabel: "height, cm"
 });
 
 export const HorizontalWithRawData : Story<Props> = Template.bind({});
@@ -137,8 +137,8 @@ HorizontalWithRawData.argTypes = storyArgTypes(
   HorizontalWithRawData.args = {
     data: [ {...catData, label: 'cats', rawData: catRawData}, {...dogData, label: 'dogs', rawData: dogRawData} ],
     showRawData: true,
-    xAxisLabel: "domestic animal",
-    yAxisLabel: "height, cm",
+    independentAxisLabel: "domestic animal",
+    dependentAxisLabel: "height, cm",
     orientation: "horizontal"
 });
 
@@ -149,8 +149,8 @@ HorizontalWithOneRawDataOneMean.argTypes = storyArgTypes(
 	    {...dogData, label: 'dogs with raw', rawData: dogRawData} ],
     showRawData: true,
     showMean: true,
-    xAxisLabel: "domestic animal",
-    yAxisLabel: "height, cm",
+    independentAxisLabel: "domestic animal",
+    dependentAxisLabel: "height, cm",
     orientation: "horizontal"
 });
 
@@ -249,7 +249,7 @@ function storyArgTypes(args : any) : any {
 	disable: args.data.filter((d : any) => d.mean !== undefined).length == 0
       }
     },
-    defaultOpacity: {
+    opacity: {
       control: {
 	disable: pointTraceIndices.length == 0
       }

--- a/src/stories/Boxplot.stories.tsx
+++ b/src/stories/Boxplot.stories.tsx
@@ -8,7 +8,7 @@ export default {
   title: 'Boxplot',
   component: Boxplot,
   argTypes: {
-    defaultOpacity: {
+    opacity: {
       control: {
 	type: 'range',
 	min: 0,
@@ -48,7 +48,7 @@ WithMean.argTypes = storyArgTypes(
   WithMean.args = {
     data: [ {...catData, label: 'cats', mean: catMean},
 	    {...dogData, label: 'dogs', mean: dogMean} ],
-    defaultShowMean: true
+    showMean: true
 });
 
 const outdoorTemperatureRawData = [ -25, -10, -5, -3, 0, 1, 2, 6, 7, 17, 18, 25, 33 ];
@@ -111,7 +111,7 @@ Horizontal.argTypes = storyArgTypes(
     data: [ {...catData, label: 'cats'}, {...dogData, label: 'dogs'} ],
     xAxisLabel: "domestic animal",
     yAxisLabel: "height, cm",
-    defaultOrientation: "horizontal"
+    orientation: "horizontal"
 });
 
 export const HorizontalLongLabels : Story<Props> = Template.bind({});
@@ -120,14 +120,14 @@ HorizontalLongLabels.argTypes = storyArgTypes(
     data: [ {...catData, label: 'hungry domestic cats'}, {...dogData, label: 'sleepy domestic dogs'} ],
     xAxisLabel: "type of domestic animal",
     yAxisLabel: "height, cm",
-    defaultOrientation: "horizontal"
+    orientation: "horizontal"
 });
 
 export const WithRawData : Story<Props> = Template.bind({});
 WithRawData.argTypes = storyArgTypes(
   WithRawData.args = {
     data: [ {...catData, label: 'cats', rawData: catRawData}, {...dogData, label: 'dogs', rawData: dogRawData} ],
-    defaultShowRawData: true,
+    showRawData: true,
     xAxisLabel: "domestic animal",
     yAxisLabel: "height, cm"
 });
@@ -136,10 +136,10 @@ export const HorizontalWithRawData : Story<Props> = Template.bind({});
 HorizontalWithRawData.argTypes = storyArgTypes(
   HorizontalWithRawData.args = {
     data: [ {...catData, label: 'cats', rawData: catRawData}, {...dogData, label: 'dogs', rawData: dogRawData} ],
-    defaultShowRawData: true,
+    showRawData: true,
     xAxisLabel: "domestic animal",
     yAxisLabel: "height, cm",
-    defaultOrientation: "horizontal"
+    orientation: "horizontal"
 });
 
 export const HorizontalWithOneRawDataOneMean : Story<Props> = Template.bind({});
@@ -147,11 +147,11 @@ HorizontalWithOneRawDataOneMean.argTypes = storyArgTypes(
   HorizontalWithOneRawDataOneMean.args = {
     data: [ {...catData, label: 'cats with mean', mean: catMean},
 	    {...dogData, label: 'dogs with raw', rawData: dogRawData} ],
-    defaultShowRawData: true,
-    defaultShowMean: true,
+    showRawData: true,
+    showMean: true,
     xAxisLabel: "domestic animal",
     yAxisLabel: "height, cm",
-    defaultOrientation: "horizontal"
+    orientation: "horizontal"
 });
 
 export const TwoColors : Story<Props> = Template.bind({});
@@ -239,12 +239,12 @@ function summaryStats(rawData : number[]) {
 function storyArgTypes(args : any) : any {
   const pointTraceIndices = args.data.map((d : any, index : number) => d.rawData || d.outliers.length ? index : -1).filter((i : number) => i>=0);
   return {
-    defaultShowRawData: {
+    showRawData: {
       control: {
 	disable: args.data.filter((d : any) => d.rawData && d.rawData.length).length == 0
       }
     },
-    defaultShowMean: {
+    showMean: {
       control: {
 	disable: args.data.filter((d : any) => d.mean !== undefined).length == 0
       }

--- a/src/stories/Boxplot.stories.tsx
+++ b/src/stories/Boxplot.stories.tsx
@@ -6,7 +6,17 @@ import _ from 'lodash';
 
 export default {
   title: 'Boxplot',
-  component: Boxplot
+  component: Boxplot,
+  argTypes: {
+    defaultOpacity: {
+      control: {
+	type: 'range',
+	min: 0,
+	max: 1,
+	step: 0.1
+      }
+    }
+  }
 } as Meta;
 
 const Template = (args : Props) => <Boxplot {...args} />;
@@ -227,6 +237,7 @@ function summaryStats(rawData : number[]) {
 }
 
 function storyArgTypes(args : any) : any {
+  const pointTraceIndices = args.data.map((d : any, index : number) => d.rawData || d.outliers.length ? index : -1).filter((i : number) => i>=0);
   return {
     defaultShowRawData: {
       control: {
@@ -238,6 +249,11 @@ function storyArgTypes(args : any) : any {
 	disable: args.data.filter((d : any) => d.mean !== undefined).length == 0
       }
     },
+    defaultOpacity: {
+      control: {
+	disable: pointTraceIndices.length == 0
+      }
+    }
   };
 }
 


### PR DESCRIPTION
Moving controls outside of the plot component means that the outside has to decide whether or not the control is appropriate to show.

I have put this logic in the storyArgTypes function.

I also now doubt calling many of the props defaultXXXX - that naming assumed that these were the defaults that the user could alter with a plot-internal control widget.